### PR TITLE
redesign main page and create visit page

### DIFF
--- a/frontend-vue-cli/src/components/LoginPage.vue
+++ b/frontend-vue-cli/src/components/LoginPage.vue
@@ -75,7 +75,7 @@ export default { //controls form input
               if(this.response.accepted == null) {
                   this.$router.push('/');
               } else if(this.response.uid != null) {
-                  this.$router.push('/main');
+                  this.$router.push('/visit');
               }
           }
         }).catch(error => {
@@ -134,7 +134,7 @@ export default { //controls form input
                 .then(data => {
                     this.response = data; 
                     if(this.status == 200) {
-                        this.$router.push('/main');
+                        this.$router.push('/visit');
                     } else {
                         this.errorMess = this.response.msg;
                         this.showError = true;

--- a/frontend-vue-cli/src/components/MainPage.vue
+++ b/frontend-vue-cli/src/components/MainPage.vue
@@ -6,15 +6,15 @@
           {{ errorMess }}
         </div>
       </div>
-      
+      <div id="alert" class="card" v-show="showAlert">
+        <div class="card-body">
+          {{ alertMess }}
+        </div>
+      </div>
+
       <button id="infoBut" class="btn btn-outline-secondary" @click="this.showInfo=!this.showInfo">Info</button>
       
       <div id="ralTop">
-        <button id="newVisitBut" class="btn btn-primary" type="submit" @click="launch">New Visit</button>
-        <select id="visitSelect" v-model="curVisit" class="btn btn-outline-primary dropdown-toggle" @change="loadVisit">
-          <option class="visitItem" v-for="item in visitList" :value="item" :key="item.visit_id">{{item.note + " " + item.datetime}}</option>
-        </select>
-
         <div id="settingsDrop" class="btn-group">
           <button type="button" class="btn btn-outline-secondary dropdown-toggle caret-off" data-bs-display="static" data-bs-toggle="dropdown" aria-expanded="false">
             <i class="bi bi-three-dots-vertical"></i>
@@ -25,26 +25,6 @@
             <li><button class="dropdown-item" type="button" @click="contact">Contact Us</button></li>
             <li><button class="dropdown-item" type="button" @click="logout">Logout</button></li>
           </ul>
-        </div>
-      </div>
-
-      <div id="visitModal" class="modal" tabindex="-1" role="dialog" aria-labelledby="exampleModalLabel" aria-hidden="true">
-        <div class="modal-dialog" role="document">
-          <div class="modal-content">
-            <div class="modal-header">
-              <h5 class="modal-title" id="exampleModalLabel">Create a New Visit</h5>
-            </div>
-            <div class="modal-body">
-              <div class="mb-3">
-                  <label for="vistnanme" class="form-label">Visit Name</label>
-                  <input type="text" class="form-control" id="visitname" v-model="visitname" placeholder="Enter a name for the visit">
-              </div>
-            </div>
-            <div class="modal-footer">
-              <button type="button" class="btn btn-success" @click="createVisit">Create Visit</button>
-              <button type="button" class="btn btn-secondary" data-dismiss="modal" @click="closeVisit">Cancel</button>
-            </div>
-          </div>
         </div>
       </div>
 
@@ -73,37 +53,6 @@
       </div>
     </div>
     <div id="middle">
-      <div class="accordion accordion-flush" id="tableAccordion">
-        <div id="findingsDiv" class="accordion-item">
-          <div id="findHead" class="accordion-header">
-            <button id="findingsTitle" class="accordion-button" type="button" data-bs-toggle="collapse" data-bs-target="#findingsBody" aria-expanded="true" aria-controls="findingsBody">
-              Top Findings
-            </button>
-          </div>
-          <div id="findingsBody" class="accordion-collapse collapse show" aria-labelledby="findHead" data-bs-parent="#tableAccordion">
-            <div class="accordion-body">
-              <input type="text" class="form-control" id="findSearch" v-model="findSearch" @input="searchFindings" placeholder="Search top findings">
-              <table id="findings" class="table table-striped table-hover align-middle table-sm">
-                <thead>
-                  <tr>
-                    <th scope="col">#</th>
-                    <th scope="col">Question</th>
-                    <th scope="col"></th>
-                  </tr>
-                </thead>
-                <tbody>
-                  <tr v-for="item in searchedFindings" :key="item.FID" @click="createNewFind(item)">
-                    <td>{{item.FID}}</td>
-                    <td>{{item.Name}}</td>
-                    <td><a :href="item.URL" class="button btn btn-link">Info</a></td>
-                  </tr>
-                </tbody>
-              </table>
-            </div>
-          </div>
-        </div>
-      </div>
-
       <div class="accordion accordion-flush" id="tableAccordion1">
         <div id="currentFindDiv" class="accordion-item">
           <div id="currentFindHead" class="accordion-header">
@@ -113,7 +62,7 @@
           </div>
           <div id="currentFindBody" class="accordion-collapse collapse show" aria-labelledby="currentFindHead" data-bs-parent="#tableAccordion1">
             <div class="accordion-body">
-              <table id="currentFind" class="table table-striped table-hover align-middle table-sm">
+              <table id="currentFind" class="table table-striped align-middle table-sm">
                 <thead>
                   <tr>
                     <th scope="col">Question</th>
@@ -136,6 +85,38 @@
         </div>
       </div>
 
+      <div class="accordion accordion-flush" id="tableAccordion">
+        <div id="findingsDiv" class="accordion-item">
+          <div id="findHead" class="accordion-header">
+            <button id="findingsTitle" class="accordion-button" type="button" data-bs-toggle="collapse" data-bs-target="#findingsBody" aria-expanded="true" aria-controls="findingsBody">
+              Top Findings
+            </button>
+          </div>
+          <div id="findingsBody" class="accordion-collapse collapse show" aria-labelledby="findHead" data-bs-parent="#tableAccordion">
+            <div class="accordion-body">
+              <button id="nbqBut" class="btn btn-primary" type="submit" @click="getNbq">Next Best Question</button>
+              <input type="text" class="form-control" id="findSearch" v-model="findSearch" @input="searchFindings" placeholder="Search top findings">
+              <table id="findings" class="table table-striped table-hover align-middle table-sm">
+                <thead>
+                  <tr>
+                    <th scope="col">#</th>
+                    <th scope="col">Question</th>
+                    <th scope="col"></th>
+                  </tr>
+                </thead>
+                <tbody>
+                  <tr v-for="item in searchedFindings" :key="item.FID" @click="createNewFind(item)">
+                    <td>{{item.FID}}</td>
+                    <td>{{item.Name}}</td>
+                    <td><a :href="item.URL" class="button btn btn-link">Info</a></td>
+                  </tr>
+                </tbody>
+              </table>
+            </div>
+          </div>
+        </div>
+      </div>
+
       <div class="accordion accordion-flush" id="tableAccordion2">
         <div id="matchesDiv" class="accordion-item">
           <div id="matchesHead" class="accordion-header">
@@ -145,7 +126,7 @@
           </div>
           <div id="matchesBody" class="accordion-collapse collapse show" aria-labelledby="matchesHead" data-bs-parent="#tableAccordion2">
             <div class="accordion-body">
-              <table id="matches" class="table table-striped table-hover align-middle table-sm">
+              <table id="matches" class="table table-striped align-middle table-sm">
                 <thead>
                   <tr>
                     <th scope="col">#</th>
@@ -200,6 +181,40 @@
         </div>
       </div>
 
+      <div id="nbqModal" class="modal" tabindex="-1" role="dialog" aria-labelledby="nbqLabel" aria-hidden="true">
+          <div class="modal-dialog" role="document">
+            <div class="modal-content">
+              <div class="modal-header">
+                <h5 class="modal-title" id="nbqLabel">Next Best Question</h5>
+              </div>
+              <div class="modal-body">
+                <div class="mb-3">
+                  <a v-if="nextBestQuestion!=null" style="font-size: 16px; font-weight: bold; margin-left: 0.4em;">{{
+                    nextBestQuestion.Name
+                  }}</a>
+                  <br>
+                  <input class="form-check-input" type="radio" name="flexRadioDefault" id="nbqYes" value="yes" v-model="nbqResp">
+                  <label class="form-check-label" for="findEditYes">
+                    Yes
+                  </label>
+                  <input class="form-check-input" type="radio" name="flexRadioDefault" id="nbqNo" value="no" v-model="nbqResp">
+                  <label class="form-check-label" for="findEditNo">
+                    No
+                  </label>
+                  <input class="form-check-input" type="radio" name="flexRadioDefault" id="nbqMaybe" value="maybe" v-model="nbqResp">
+                  <label class="form-check-label" for="findEditMaybe">
+                    Not Sure
+                  </label>
+                </div>
+              </div>
+              <div class="modal-footer">
+                <button type="button" class="btn btn-success" @click="confirmNbq">Update</button>
+                <button type="button" class="btn btn-secondary" data-dismiss="modal" @click="closeNbq">Cancel</button>
+              </div>
+            </div>
+          </div>
+      </div>
+
       <div id="newFindModal" class="modal" tabindex="-1" role="dialog" aria-labelledby="newFindLabel" aria-hidden="true">
         <div class="modal-dialog" role="document">
           <div class="modal-content">
@@ -237,52 +252,52 @@
     <br>
     <div id="bot">
       <div id="botButs">
-        <button id="nbqBut" class="btn btn-success" type="submit" @click="getNbq">Next Best Question</button>
+        <div id="lalBot">
+          <button id="saveBut" class="btn btn-primary" type="submit" @click="save">Save</button>
+          <button id="editNameBut" class="btn btn-outline-primary" type="submit" @click="createEditNote">Rename</button>
+        </div>
+        <div id="ralBot">
+          <button id="resetBut" class="btn btn-outline-secondary" type="submit" @click="reset">Reset</button>
+          <button id="backBut" class="btn btn-secondary" type="submit" @click="$router.go(-1)">Back</button>
+        </div>
       </div>
 
-      <div id="nbqModal" class="modal" tabindex="-1" role="dialog" aria-labelledby="nbqLabel" aria-hidden="true">
-          <div class="modal-dialog" role="document">
-            <div class="modal-content">
-              <div class="modal-header">
-                <h5 class="modal-title" id="nbqLabel">Next Best Question</h5>
+      <div id="editNoteModal" class="modal" tabindex="-1" role="dialog" aria-labelledby="editNoteLabel" aria-hidden="true">
+        <div class="modal-dialog" role="document">
+          <div class="modal-content">
+            <div class="modal-header">
+              <h5 class="modal-title" id="editNoteLabel">Change Visit Name</h5>
+            </div>
+            <div class="modal-body">
+              <div class="mb-3">
+                <label class="form-check-label" for="editNodeInput">
+                  Enter Visit Name:
+                </label>
+                <input type="text" class="form-control" id="editNodeInput" v-model="newNodeVal" placeholder="Enter name">
               </div>
-              <div class="modal-body">
-                <div class="mb-3">
-                  <a v-if="nextBestQuestion!=null" style="font-size: 16px; font-weight: bold; margin-left: 0.4em;">{{
-                    nextBestQuestion.Name
-                  }}</a>
-                  <br>
-                  <input class="form-check-input" type="radio" name="flexRadioDefault" id="nbqYes" value="yes" v-model="nbqResp">
-                  <label class="form-check-label" for="findEditYes">
-                    Yes
-                  </label>
-                  <input class="form-check-input" type="radio" name="flexRadioDefault" id="nbqNo" value="no" v-model="nbqResp">
-                  <label class="form-check-label" for="findEditNo">
-                    No
-                  </label>
-                  <input class="form-check-input" type="radio" name="flexRadioDefault" id="nbqMaybe" value="maybe" v-model="nbqResp">
-                  <label class="form-check-label" for="findEditMaybe">
-                    Not Sure
-                  </label>
-                </div>
-              </div>
-              <div class="modal-footer">
-                <button type="button" class="btn btn-success" @click="confirmNbq">Update</button>
-                <button type="button" class="btn btn-secondary" data-dismiss="modal" @click="closeNbq">Cancel</button>
-              </div>
+            </div>
+            <div class="modal-footer">
+              <button type="button" class="btn btn-success" @click="makeEditNote">Confirm</button>
+              <button type="button" class="btn btn-danger" data-dismiss="modal" @click="closeEditNote">Cancel</button>
             </div>
           </div>
         </div>
       </div>
+      </div>
   </div>
 </template>
-
+  
 <script>
   export default { //controls form input
     name: "MainPage",
     props: {
+      visit: {
+        type: Number,
+        default: 0
+      }
     },
     beforeCreate: async function () {
+      //console.log(this.$route.query.visit);
       let url = "http://127.0.0.1:5001/user/sessiondata";
       await fetch(url, { //executes the query with a promise to get around asynchronous javascript behavior
         method: 'get',
@@ -320,8 +335,9 @@
             }
         }
         });
-        url = "http://127.0.0.1:5001/visit";
-        fetch(url, { //executes the query with a promise to get around asynchronous javascript behavior
+        if(this.$route.query.visit > 0) {
+          url = "http://127.0.0.1:5001/visit";
+          await fetch(url, { //executes the query with a promise to get around asynchronous javascript behavior
                 method: 'GET',
                 credentials: "include",
                 mode: 'cors',
@@ -341,8 +357,8 @@
                     if(this.status == 200) {
                         let li = this.response.result;
                         for(let i=0;i<li.length;i++) {
-                          if(li[i].visit_id > 0) {
-                            this.visitList.push(li[i]);
+                          if(li[i].visit_id == this.$route.query.visit) {
+                            this.curVisit = li[i];
                           }
                         }
                     } else {
@@ -358,21 +374,24 @@
                         }
                     }
                 });
+          this.loadVisit();
+        } else {
+          this.curVisit = {'note': "New Visit", 'visit_id': 0, 'datetime': ""};
+          this.loadVisit();
+        }
     },
     data() {
         return {
             query: "",
-            message: "AI Interal Medicine searches a large database to diagnose you. To start simply select a visit and enter your symptoms.",
+            message: "AI Interal Medicine searches a large database to diagnose you. Your symptoms are displayed in the Current Findings table. Use the Top Findings table to search for and enter more of your symptoms. The best matches from the database are found in the Top Diseases table.",
             showInfo: false,
             showError: false,
             errorMess: "",
+            alertMess: "",
+            showAlert: false,
             response: {},
             status: 0,
-            visitList: [ //should hide all inputs when an actual visit isnt selected
-              {'note': 'Select a Visit', 'visit_id': 0, 'datetime': ""}], 
-            curVisit: {'note': 'Select a Visit', 'visit_id': 0, 'datetime': ""},
-            visitname: "",
-            visitInit: false,
+            curVisit: {'note': 'New Visit', 'visit_id': 0, 'datetime': ""},
             findingsList: [
               {'Name': 'Gender is Male?', 'FID': 1, 'URL': 'https://www.google.com'},
               {'Name': 'Age is between 16 and 50?', 'FID': 2, 'URL': 'https://www.google.com'},
@@ -393,7 +412,8 @@
             newFindQuestion: null,
             newFindResp: null,
             nextBestQuestion: null,
-            nbqResp: null
+            nbqResp: null,
+            newNodeVal: ""
         }
     },
     methods: {
@@ -429,22 +449,8 @@
           });
       },
       loadVisit: async function() {
-        let item = this.curVisit;
-        if(item.visit_id > 0 && this.visitList[0].visit_id < 1) {
-          if(item.visit_id !== 0 && !this.visitInit) { //remove initial select option
-            this.visitList.splice(0,1);
-            this.visitInit = true;
-          }
-        }
-        //await this.getDiseases();
         await this.getCurrentFindings();
         this.getDiseases();
-      },
-      launch: function() {
-        /*eslint-disable */
-        //suppress all warnings between comments
-        $('#visitModal').modal('show'); //need to do this disable because eslint doesnt understand jquery for some reason
-        /*eslint-enable */
       },
       contact: function() {
         /*eslint-disable */
@@ -456,55 +462,6 @@
         /*eslint-disable */
         //suppress all warnings between comments
         $('#contactModal').modal('hide'); //need to do this disable because eslint doesnt understand jquery for some reason
-        /*eslint-enable */
-      },
-      createVisit: function() {
-        let url = "http://127.0.0.1:5001/visit";
-            fetch(url, { //executes the query with a promise to get around asynchronous javascript behavior
-                method: 'POST',
-                credentials: "include",
-                mode: 'cors',
-                headers: {
-                    'Content-Type': 'application/json;charset=UTF-8',
-                    "Set-Cookie": "test=value; Path=/; Secure; SameSite=None;",
-                    'Access-Control-Allow-Origin': '127.0.0.1:5001',
-                    'Access-Control-Allow-Credentials': true,
-                },
-                body:  JSON.stringify({
-                  'note': this.visitname
-                })
-                })
-                .then((response) => { 
-                    this.status = response.status;
-                    return response.json() 
-                })
-                .then(data => {
-                    this.response = data; 
-                    if(this.status == 200) {
-                        this.visitList = this.response.result;
-                        this.curVisit = this.visitList[this.response.index];
-                        this.closeVisit();
-                    } else {
-                        this.errorMess = this.response.msg;
-                        this.showError = true;
-                        this.closeVisit();
-                    }
-                    }).catch(error => {
-                    if(error.response) {
-                        console.log("Error: " + error.message);
-                        if(this.status == 401) {
-                            this.errorMess = error.response.data.msg;
-                            this.showError = true;
-                            this.closeVisit();
-                        }
-                    }
-                });
-      },
-      closeVisit: function() {
-        this.visitname = "";
-        /*eslint-disable */
-        //suppress all warnings between comments
-        $('#visitModal').modal('hide'); //need to do this disable because eslint doesnt understand jquery for some reason
         /*eslint-enable */
       },
       createEditFind: function(item) {
@@ -688,169 +645,295 @@
                         }
                     }
                 });
-      }
+      },
+      reset: async function() {
+        this.findingsList = [];
+        this.searchedFindings = [];
+        this.currentFindings = [];
+        this.matchesList = [];
+        let vid = this.curVisit.visit_id;
+        this.curVisit.visit_id = 0;
+        await this.loadVisit();
+        this.curVisit.visit_id = vid;
+      },
+      save: async function() {
+        this.showAlert = false;
+        this.showError = false;
+        let suc = false;
+        //do query, probably as async await
+        if(this.curVisit.visit_id == 0) { //new visit, create visit
+          let url = "http://127.0.0.1:5001/visit";
+          await fetch(url, { //executes the query with a promise to get around asynchronous javascript behavior
+            method: 'POST',
+            credentials: "include",
+            mode: 'cors',
+            headers: {
+                'Content-Type': 'application/json;charset=UTF-8',
+                "Set-Cookie": "test=value; Path=/; Secure; SameSite=None;",
+                'Access-Control-Allow-Origin': '127.0.0.1:5001',
+                'Access-Control-Allow-Credentials': true,
+            },
+            body:  JSON.stringify({
+                'note': this.curVisit.note
+            })
+            })
+            .then((response) => { 
+                this.status = response.status;
+                return response.json() 
+            })
+            .then(data => {
+                this.response = data; 
+                if(this.status == 200) {
+                    //console.log(this.response); //seems like the query isnt passing back the right visit
+                    this.curVisit = this.response.result[this.response.index];
+                    suc = true;
+                } else {
+                    this.errorMess = this.response.msg;
+                    this.showError = true;
+                }
+                }).catch(error => {
+                if(error.response) {
+                    console.log("Error: " + error.message);
+                    if(this.status == 401) {
+                        this.errorMess = error.response.data.msg;
+                        this.showError = true;
+                    }
+                }
+            });
+        } else { //update visit
+          suc = true; //placeholder
+        }
+        //on success perform the followings
+        if(suc) {
+          this.alertMess = "Changes saved successfully.";
+          this.showAlert = true;
+          setTimeout(() => {this.showAlert = false}, 5000);
+        } else {
+          this.errorMess = "Failed to save changes.";
+          this.showError = true;
+          setTimeout(() => {this.showError = false}, 5000);
+        }
+      },
+      createEditNote: function() {
+        this.newNodeVal = ""; //this.curVisit.note;
+        /*eslint-disable */
+        //suppress all warnings between comments
+        $('#editNoteModal').modal('show'); //need to do this disable because eslint doesnt understand jquery for some reason
+        /*eslint-enable */
+      },
+      closeEditNote: function() {
+        /*eslint-disable */
+        //suppress all warnings between comments
+        $('#editNoteModal').modal('hide'); //need to do this disable because eslint doesnt understand jquery for some reason
+        /*eslint-enable */
+      },
+      makeEditNote: function() {
+        //console.log(this.newNodeVal);
+        if(this.newNodeVal == null || this.newNodeVal == "") {
+          this.errorMess = "Please enter a name.";
+          this.showError = true;
+          setTimeout(() => {this.showError = false}, 5000);
+        } else {
+          this.curVisit.note = this.newNodeVal;
+        }
+        this.closeEditNote();
+      },
     }
   }
 </script>
 
 <style>
-  #appinfo {
-    margin-top: 0.4em;
-    margin-bottom: 0.4em;
-    margin-left: 0.6em;
-    margin-right: 0.6em;
-    font-size: 14px;
-    font-weight: normal;
-  }
-  #error {
-    color: rgb(255, 10, 67);
+#appinfo {
+  margin-top: 0.4em;
+  margin-bottom: 0.4em;
+  margin-left: 0.6em;
+  margin-right: 0.6em;
+  font-size: 14px;
+  font-weight: normal;
+}
+#error {
+  color: rgb(255, 10, 67);
+  margin-top: 0.2em;
+  margin-bottom: 0.2em;
+  margin-left: 0.6em;
+  margin-right: 0.6em;
+}
+#alert {
+    color: rgb(40, 190, 90);
     margin-top: 0.2em;
     margin-bottom: 0.2em;
     margin-left: 0.6em;
     margin-right: 0.6em;
   }
-  #main {
-    display: flex;
-    flex-direction: column;
-  }
-  #top {
-    margin-top: 0.4em;
-    margin-bottom: 0.4em;
-  }
-  #middle {
-    background-color: rgb(235,236,237);
-    height: 37em;
-    font-weight: normal;
-    font-size: 14px;
-    overflow-y: scroll;
-  }
-  #bot {
-    font-weight: normal;
-    font-size: 14px;
-  }
-  #ralTop {
-    float: right;
-    display: inline;
-  }
-  #infoBut {
-    margin-left: 0.6em;
-  }
-  #logoutBut {
-    margin-left: 0.6em;
-  }
-  #formbtn {
-    display: inline;
-  }
-  #newVisitBut {
-    margin-right: 0.6em;
-  }
-  .visitItem {
-    background-color: #f7f7f7;
-    color: #0275d8;
-  }
-  .dropdown {
-    display: block;
-    float:left;
-  }
-  .caret-off::before {
-    display: none;
-  }
-  .caret-off::after {
-    display: none;
-  }
-  .modal-header {
+#main {
+  display: flex;
+  flex-direction: column;
+}
+#top {
+  margin-top: 0.4em;
+  margin-bottom: 0.4em;
+}
+#middle {
+  background-color: rgb(235,236,237);
+  height: 37em;
+  font-weight: normal;
+  font-size: 14px;
+  overflow-y: scroll;
+}
+#bot {
+  font-weight: normal;
+  font-size: 14px;
+}
+#ralTop {
+  float: right;
+  display: inline;
+}
+#infoBut {
+  margin-left: 0.6em;
+}
+#logoutBut {
+  margin-left: 0.6em;
+}
+#formbtn {
+  display: inline;
+}
+#newVisitBut {
+  margin-right: 0.6em;
+}
+.visitItem {
+  background-color: #f7f7f7;
+  color: #0275d8;
+}
+.dropdown {
+  display: block;
+  float:left;
+}
+.caret-off::before {
+  display: none;
+}
+.caret-off::after {
+  display: none;
+}
+.modal-header {
+  background-color: rgb(250, 251, 252);
+}
+.modal-footer {
     background-color: rgb(250, 251, 252);
+}
+#settingsDrop {
+  margin-right: 0.8em;
+}
+#visitSelect {
+  margin-right: 0.6em;
+  height: 2.4em;
+  display: inline;
+}
+.visitItem {
+  height: 2.0em;
+  text-align-last: center;
+}
+option{
+    text-align-last: center;
+    padding:5px 0;
   }
-  .modal-footer {
-     background-color: rgb(250, 251, 252);
-  }
-  #settingsDrop {
-    margin-right: 0.8em;
-  }
-  #visitSelect {
+  #findings {
+    margin-left: 0.6em;
     margin-right: 0.6em;
-    height: 2.4em;
+    width: 99%;
+    max-height: 30%;
+    overflow: scroll;
+  }
+  #findingsTitle {
+    font-weight: bold;
+    font-size: 18px;
+    margin-top: 0.4em;
+  }
+  #currentFindTitle {
+    font-weight: bold;
+    font-size: 18px;
+    margin-top: 0.4em;
+  }
+  #currentFind {
+    margin-left: 0.6em;
+    margin-right: 0.6em;
+    width: 99%;
+    max-height: 30%;
+    overflow: scroll;
+  }
+  #matches {
+    margin-left: 0.6em;
+    margin-right: 0.6em;
+    width: 99%;
+    max-height: 30%;
+    overflow: scroll;
+  }
+  #matchesTitle {
+    font-weight: bold;
+    font-size: 18px;
+    margin-top: 0.4em;
+  }
+  #findingsDiv {
+    background-color: rgb(248, 249, 250);
+  }
+  #matchesDiv {
+    background-color: rgb(248, 249, 250);
+  }
+  #findHead {
     display: inline;
   }
-  .visitItem {
-    height: 2.0em;
-    text-align-last: center;
+  #findSearch {
+    max-width: 40%;
+    float: right;
+    margin-right:1em;
+    height: 2.5em;
+    margin-top:0.5em;
   }
-  option{
-     text-align-last: center;
-     padding:5px 0;
-   }
-   #findings {
-     margin-left: 0.6em;
-     margin-right: 0.6em;
-     width: 99%;
-     max-height: 30%;
-     overflow: scroll;
-   }
-   #findingsTitle {
-     font-weight: bold;
-     font-size: 18px;
-     margin-top: 0.4em;
-   }
-   #currentFindTitle {
-     font-weight: bold;
-     font-size: 18px;
-     margin-top: 0.4em;
-   }
-   #currentFind {
-     margin-left: 0.6em;
-     margin-right: 0.6em;
-     width: 99%;
-     max-height: 30%;
-     overflow: scroll;
-   }
-   #matches {
-     margin-left: 0.6em;
-     margin-right: 0.6em;
-     width: 99%;
-     max-height: 30%;
-     overflow: scroll;
-   }
-   #matchesTitle {
-     font-weight: bold;
-     font-size: 18px;
-     margin-top: 0.4em;
-   }
-   #findingsDiv {
-     background-color: rgb(248, 249, 250);
-   }
-   #matchesDiv {
-     background-color: rgb(248, 249, 250);
-   }
-   #findHead {
-     display: inline;
-   }
-   #findSearch {
-     max-width: 40%;
-     float: right;
-     margin-right:1em;
-     height: 2.5em;
-     margin-top:0.5em;
-   }
-   #findEditYes, #findEditNo, #findEditMaybe {
-     margin-right:0.5em;
-     margin-left:0.5em;
-   }
-   #botButs {
-     margin-left:0.5em;
-     margin-right:0.5em;
-   }
-   #nbqYes, #nbqNo, #nbqMaybe {
-     margin-right:0.5em;
-     margin-left:0.5em;
-   }
-   .accordion {
-     width: 99%
-   }
-   .accordion-item {
-     margin-left:1em;
-   }
-   .accordion-body {
-     background-color: rgb(248, 249, 250);
-   }
+  #findEditYes, #findEditNo, #findEditMaybe {
+    margin-right:0.5em;
+    margin-left:0.5em;
+  }
+  #botButs {
+    margin-left:0.5em;
+    margin-right:0.5em;
+  }
+  #nbqYes, #nbqNo, #nbqMaybe {
+    margin-right:0.5em;
+    margin-left:0.5em;
+  }
+  #nbqBut {
+    margin-left: 0.4em;
+    margin-top: 0.4em;
+  }
+  .accordion {
+    width: 99%
+  }
+  .accordion-item {
+    margin-left:1em;
+  }
+  .accordion-body {
+    background-color: rgb(248, 249, 250);
+  }
+  #lalBot {
+    float: left;
+    margin-left: 0.4em;
+  }
+  #ralBot {
+    float: right;
+    margin-right: 0.6em;
+    margin-top: -0.35em;
+  }
+  #saveBut {
+    margin-right: 0.5em;
+  }
+  #editNameBut {
+
+  }
+  #resetBut {
+    margin-top: 0.3em;
+  }
+  #backBut {
+    margin-left: 0.5em;
+    margin-top: -0.5em;
+  }
 </style>
+    

--- a/frontend-vue-cli/src/components/VisitPage.vue
+++ b/frontend-vue-cli/src/components/VisitPage.vue
@@ -1,0 +1,216 @@
+<template>
+  <div id="main">
+    <div id="top">
+      <div id="error" class="card" v-show="showError">
+        <div class="card-body">
+          {{ errorMess }}
+        </div>
+      </div>
+      <div id="appinfo" class="card" v-show="showInfo"> 
+        <div class="card-body">
+          {{ message }} 
+        </div>
+      </div>
+      
+      <div id="buttonSection">
+        <button type="submit" class="btn btn-primary" id="confirmBut" @click='loadVisit'>Confirm</button>
+        <select id="visitSelect" v-model="curVisit" class="btn btn-outline-primary dropdown-toggle">
+          <option class="visitItem" v-for="item in visitList" :value="item" :key="item.visit_id">{{item.note + " " + item.datetime}}</option>
+        </select>
+        <br>
+        <button id="newVisitBut" class="btn btn-secondary" type="submit" @click="createVisit">New Visit</button>
+      </div>
+    </div>
+  </div>
+</template>
+
+<script>
+  export default { //controls form input
+    name: "VisitPage",
+    props: {
+    },
+    beforeCreate: async function () {
+      let url = "http://127.0.0.1:5001/user/sessiondata";
+      await fetch(url, { //executes the query with a promise to get around asynchronous javascript behavior
+        method: 'get',
+        credentials: "include",
+        mode: 'cors',
+        headers: {
+            'Content-Type': 'application/json;charset=UTF-8',
+            "Set-Cookie": "test=value; Path=/; Secure; SameSite=None;",
+            'Access-Control-Allow-Origin': '127.0.0.1:5001',
+            'Access-Control-Allow-Credentials': true,
+        }})
+        .then((response) => { 
+            this.status = response.status;
+            return response.json() 
+        })
+        .then(data => {
+          this.response = data; //update table with new data
+          if(this.status == 200) {
+              if(this.response.accepted == null) {
+                  this.$router.push('/');
+              }
+              else if(this.response.uid == null) {
+                  this.$router.push('/login');
+              }
+          } else {
+            console.log('bad');
+              this.$router.push('/');
+          }
+        }).catch(error => {
+        if(error.response) {
+            if(this.status == 200) {
+              console.log(this.response.msg); //switch to main page here
+            } else {
+              this.$router.push('/');
+            }
+        }
+        });
+        url = "http://127.0.0.1:5001/visit";
+        fetch(url, { //executes the query with a promise to get around asynchronous javascript behavior
+                method: 'GET',
+                credentials: "include",
+                mode: 'cors',
+                headers: {
+                    'Content-Type': 'application/json;charset=UTF-8',
+                    "Set-Cookie": "test=value; Path=/; Secure; SameSite=None;",
+                    'Access-Control-Allow-Origin': '127.0.0.1:5001',
+                    'Access-Control-Allow-Credentials': true,
+                }
+                })
+                .then((response) => { 
+                    this.status = response.status;
+                    return response.json() 
+                })
+                .then(data => {
+                    this.response = data; 
+                    if(this.status == 200) {
+                        let li = this.response.result;
+                        for(let i=0;i<li.length;i++) {
+                          if(li[i].visit_id > 0) {
+                            this.visitList.push(li[i]);
+                          }
+                        }
+                    } else {
+                        this.errorMess = this.response.msg;
+                        this.showError = true;
+                    }
+                    }).catch(error => {
+                    if(error.response) {
+                        console.log("Error: " + error.message);
+                        if(this.status == 401) {
+                            this.errorMess = error.response.data.msg;
+                            this.showError = true;
+                        }
+                    }
+                });
+    },
+    data() {
+        return {
+            query: "",
+            message: "Select a visit from the dropdown and confirm, or create a new visit.",
+            showInfo: true,
+            showError: false,
+            errorMess: "",
+            response: {},
+            status: 0,
+            visitList: [ //should hide all inputs when an actual visit isnt selected
+              {'note': 'Select a Visit', 'visit_id': 0, 'datetime': ""}], 
+            curVisit: {'note': 'Select a Visit', 'visit_id': 0, 'datetime': ""},
+            visitname: ""
+        }
+    },
+    methods: {
+      loadVisit: async function() {
+        this.showError = false;
+        if(this.curVisit != null && this.curVisit.visit_id > 0) {
+            this.$router.push('/main?visit='+this.curVisit.visit_id);
+        } else {
+            this.errorMess = "Please select a visit before confirming, or create a new visit."
+            this.showError = true;
+        }
+      },
+      createVisit: function() {
+        this.$router.push('/main?visit=0');
+      }
+    }
+  }
+</script>
+
+<style>
+  #appinfo {
+    margin-top: 0.4em;
+    margin-bottom: 0.4em;
+    margin-left: 0.6em;
+    margin-right: 0.6em;
+    font-size: 14px;
+    font-weight: normal;
+  }
+  #error {
+    color: rgb(255, 10, 67);
+    margin-top: 0.2em;
+    margin-bottom: 0.2em;
+    margin-left: 0.6em;
+    margin-right: 0.6em;
+  }
+  #main {
+    display: flex;
+    flex-direction: column;
+  }
+  #infoBut {
+    margin-left: 0.6em;
+  }
+  #logoutBut {
+    margin-left: 0.6em;
+  }
+  #formbtn {
+    display: inline;
+  }
+  #newVisitBut {
+    margin-right: 0.6em;
+  }
+  .visitItem {
+    background-color: #f7f7f7;
+    color: #0275d8;
+  }
+  .dropdown {
+    display: block;
+    float:left;
+  }
+  .caret-off::before {
+    display: none;
+  }
+  .caret-off::after {
+    display: none;
+  }
+  .modal-header {
+    background-color: rgb(250, 251, 252);
+  }
+  .modal-footer {
+     background-color: rgb(250, 251, 252);
+  }
+  #visitSelect {
+    margin-right: 0.6em;
+    height: 2.4em;
+    display: inline;
+  }
+  .visitItem {
+    height: 2.0em;
+    text-align-last: center;
+  }
+  option{
+     text-align-last: center;
+     padding:5px 0;
+   }
+   #confirmBut {
+       margin-right: 0.4em;
+   }
+   #newVisitBut {
+       margin-top: 0.5em;
+   }
+   #buttonSection {
+       margin-top: 0.5em;
+       margin-left: 0.6em;
+   }
+</style>

--- a/frontend-vue-cli/src/routes.js
+++ b/frontend-vue-cli/src/routes.js
@@ -4,11 +4,13 @@ import RegisterPage from './components/RegisterPage.vue';
 import MainPage from './components/MainPage';
 import ForgetPage from './components/ForgetPage';
 import NewPassPage from './components/NewPassPage';
+import VisitPage from './components/VisitPage';
 
 const routes = [
     {path: '/login', component: LoginPage, props: true},
     {path: '/', component: DisclaimerPage},
     {path: '/register', component: RegisterPage},
+    {path: '/visit', component: VisitPage},
     {path: '/main', component: MainPage},
     {path: '/forget', component: ForgetPage},
     {path: '/newpass', component: NewPassPage, props: true}


### PR DESCRIPTION
Created the visit page with the old functionality that used to be on the main page. Added the visit page between the login and main pages. The main page now gets passed the visit_id as a prop, which it uses to the query the backend to get the rest of the visit info, if necessary. 
Redesigned the main page to fit with the new designs, and added in 4 new buttons: save, reset, back, and rename. Save will need a new backend query, but I think the other ones are fully implemented. In general this page still needs a lot of integration with the backend, and even some of the queries I am making use of now could probably be optimized later, as they are not all necessarily meant for the task that I am using them for now after the page redesign.